### PR TITLE
Speed up the deployment and save the tokens to API Gateway stage variables

### DIFF
--- a/api/handler.js
+++ b/api/handler.js
@@ -1,11 +1,11 @@
 const apiai = require('apiai');
 const Promise = require('promise');
 const moment = require('moment');
-const app = apiai("YOUR_ACCESS_TOKEN");
 const Slack = require('./slack');
 
 module.exports = {
-    reply: function(message) {
+    reply: function(message, env) {
+        const app = apiai(env.apiAiToken);
         var type = message.type;
         var sender = message.originalRequest.user_name;
         var command = message.originalRequest.command;
@@ -18,7 +18,7 @@ module.exports = {
         return new Promise(function(resolve, reject) {
             switch (message.type) {
                 case 'slack-slash-command':
-                    Slack.processCommand(command, args, sender).then(function(reply) {
+                    Slack.processCommand(command, args, sender, env).then(function(reply) {
                         resolve(reply);
                     }).catch(function(error) {
                         reject(error);

--- a/api/outlook.js
+++ b/api/outlook.js
@@ -17,9 +17,9 @@ module.exports = {
     getRoomStatus: function(room) {
 
     },
-    getRoomEvents: function(room) {
+    getRoomEvents: function(room, env) {
         // This is the oAuth token
-        var token = 'eyJ0eXAiOiJKV1Q...';
+        var token = env.outlookToken;
 
         // Set up oData parameters
         var queryParams = {

--- a/api/slack.js
+++ b/api/slack.js
@@ -4,7 +4,7 @@ const Outlook = require('./outlook');
 const Utils = require('../Utils/utils');
 
 module.exports = {
-  processCommand: function(command, args, sender){
+  processCommand: function(command, args, sender, env){
     return new Promise(function(resolve, reject) {
       var reply;
       switch (command) {

--- a/app.js
+++ b/app.js
@@ -1,12 +1,19 @@
 const botBuilder = require('claudia-bot-builder');
 const Handler = require('./api/handler.js');
 
-module.exports = botBuilder(function (message) {
+const api = botBuilder(function (message, originalApiRequest) {
 
-  return Handler.reply(message).then(function(reply){
+  return Handler.reply(message, originalApiRequest.env).then(function(reply){
     return reply;
   }).catch(function(error){
     return error;
   });
 
+}, {
+  platforms: ['slackSlashCommand']
 });
+
+api.addPostDeployConfig('apiAiToken', 'Enter your API.ai token:', 'configure-bot');
+api.addPostDeployConfig('outlookToken', 'Enter your Outlook token:', 'configure-bot');
+
+module.exports = api;


### PR DESCRIPTION
A few updates:

1. `platforms: ['slackSlashCommand']` speeds up the deployment because it doesn't create API endpoints for the other platforms
2. With `api.addPostDeployConfig('envVariable', 'Description', 'configure-bot');` you can run `claudia update --configure-bot` and it will ask you to provide `envVariable` and store it to API Gateway stage variable, that way you don't need to hardcode any tokens in the code (ie. api.ai token, outlook token, etc.)

PS. If you finish this bot please let me know so we can add it to the list of bots build with Claudia Bot Builder.

Cheers,
Slobodan